### PR TITLE
POC for DPAPI-protected storage of refresh tokens in config file

### DIFF
--- a/KoenZomers.KeePass.OneDriveSync/Enums/OneDriveRefreshTokenStorage.cs
+++ b/KoenZomers.KeePass.OneDriveSync/Enums/OneDriveRefreshTokenStorage.cs
@@ -18,6 +18,11 @@
         /// <summary>
         /// Saves the RefreshToken in the encrypted KeePass database
         /// </summary>
-        KeePassDatabase = 2
+        KeePassDatabase = 2,
+
+        /// <summary>
+        /// Saves the RefreshToken encrypted with DPAPI in KeePass.config.xml located in %APPDATA%\KeePass 
+        /// </summary>
+        DiskEncrypted = 3,
     }
 }

--- a/KoenZomers.KeePass.OneDriveSync/Forms/OneDriveRefreshTokenStorageDialog.cs
+++ b/KoenZomers.KeePass.OneDriveSync/Forms/OneDriveRefreshTokenStorageDialog.cs
@@ -37,7 +37,7 @@ namespace KoenZomersKeePassOneDriveSync
             }
             if (OnDiskRadio.Checked)
             {
-                _configuration.RefreshTokenStorage = OneDriveRefreshTokenStorage.Disk;
+                _configuration.RefreshTokenStorage = OneDriveRefreshTokenStorage.DiskEncrypted;
             }
         }
     }

--- a/KoenZomers.KeePass.OneDriveSync/KoenZomers.KeePass.OneDriveSync.csproj
+++ b/KoenZomers.KeePass.OneDriveSync/KoenZomers.KeePass.OneDriveSync.csproj
@@ -69,6 +69,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />


### PR DESCRIPTION
As discussed in issue #84.

Uses the ProtectedData.Protect and ProtectedData.Unprotect methods for encrypting and decrypting Refresh Tokens when storing in configuration files. Protection is done under current user scope, meaning that only the currently logged-in user will be able to unprotect the data.

Existing plaintext tokens will be silently encrypted on config save.

The decoding method returns NULL on failure to decrypt the token (similar to the handling in the Windows Credential Manager storage). Same for the encoding method.

I've only done some quick testing on this, but it seems to work fine so far.