### PR TITLE
Correctly normalize relative kdbx paths

### DIFF
--- a/KoenZomers.KeePass.OneDriveSync/Forms/OneDriveConfigForm.cs
+++ b/KoenZomers.KeePass.OneDriveSync/Forms/OneDriveConfigForm.cs
@@ -46,7 +46,7 @@ namespace KoenZomersKeePassOneDriveSync
             // Clear the existing items
             ConfigurationListView.Items.Clear();
 
-            var configurations = Configuration.PasswordDatabases;
+            var configurations = Configuration.GetAllConfigurations();
 
             foreach (var configuration in configurations)
             {

--- a/KoenZomers.KeePass.OneDriveSync/KeePassDatabase.cs
+++ b/KoenZomers.KeePass.OneDriveSync/KeePassDatabase.cs
@@ -63,7 +63,7 @@ namespace KoenZomersKeePassOneDriveSync
             databaseConfig.LastSyncedAt = DateTime.Now;
             databaseConfig.LastCheckedAt = DateTime.Now;
 
-            Configuration.PasswordDatabases[localKeePassDatabasePath] = databaseConfig;
+            databaseConfig = Configuration.GetPasswordDatabaseConfiguration(localKeePassDatabasePath);
             Configuration.Save();
 
             UpdateStatus("Opening KeePass database");


### PR DESCRIPTION
Changed all accesses to Configuration objects to be via GetPasswordDatabaseConfiguration method, which has a file path normalization step inserted into it. This allows relative paths to work correctly.

Consequences: Made Configuration property private
Moved IsSomethingStillRunning to Configuration object
Removed path mangling checks in KoenZomersKeePassOneDriveSyncExt (moved to Configuration.GetPasswordDatabaseConfiguration)
Changed KeePassDatabase.OpenDatabaseFromCloudService to use GetPasswordDatabaseConfiguration also